### PR TITLE
fix: modlookup command permissions

### DIFF
--- a/bot/commands/lookupMods.js
+++ b/bot/commands/lookupMods.js
@@ -22,7 +22,11 @@ module.exports = {
 
     const data = "```" + mods.join("\n") + "```";
 
-    if (interaction.guild.roles.cache.find(role => role.name === "Admin")) {
+    const user = interaction.guild.members.cache.find(
+      members => members.user.id === interaction.user.id
+    );
+
+    if (user._roles.includes(process.env.ADMIN_ROLE_ID)) {
       return interaction.editReply({
         content: data
       });


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/NoPixel-Mod-Discord/discord-bot/canary?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=NoPixel-Mod-Discord&repo=discord-bot&branch=canary">VS Code</a>

<!-- open-in-codesandbox:complete -->


